### PR TITLE
fix(receipt): show error in json format

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ucan-chrome-ext",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Devtools extension to look at web requests",
   "main": "index.js",
   "scripts": {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "UCan See My Request",
   "description": "Inspect UCAN requests",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "manifest_version": 3,
   "devtools_page": "devtools.html"
 }

--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -119,7 +119,7 @@ function CollapsableRow({ header, children} : React.PropsWithChildren<{header:st
 }
 function ReceiptDisplay({receipt} : { receipt : Receipt }) {
   const index = {
-    Out: receipt.out.ok ? <pre>{JSON.stringify(receipt.out.ok, bigIntSafe, 4)}</pre> : `Error: ${formatError(receipt.out.error)}`,
+    Out: receipt.out.ok ? <pre>{JSON.stringify(receipt.out.ok, bigIntSafe, 2)}</pre> : `Error: ${formatError(receipt.out.error)}`,
   }
   return (
     <Accordion>

--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -8,7 +8,7 @@ import Box from '@mui/material/Box';
 import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader';
 import CardContent from '@mui/material/CardContent';
-import {shortString, bigIntSafe, messageFromRequest, decodeMessage} from './util'
+import {shortString, bigIntSafe, messageFromRequest, decodeMessage, formatError} from './util'
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
@@ -119,7 +119,7 @@ function CollapsableRow({ header, children} : React.PropsWithChildren<{header:st
 }
 function ReceiptDisplay({receipt} : { receipt : Receipt }) {
   const index = {
-    Out: receipt.out.ok ? <pre>{JSON.stringify(receipt.out.ok, bigIntSafe, 4)}</pre> : `Error: ${receipt.out.error}`,
+    Out: receipt.out.ok ? <pre>{JSON.stringify(receipt.out.ok, bigIntSafe, 4)}</pre> : `Error: ${formatError(receipt.out.error)}`,
   }
   return (
     <Accordion>

--- a/src/util.ts
+++ b/src/util.ts
@@ -35,3 +35,14 @@ export const shortString = (st : string, n: number) => st.length > n ? st.substr
 export function isCarRequest(request : Request) {
   return request.request.headers.some((header) => header.name.toLowerCase() == 'content-type' && header.value == CAR.contentType)
 }
+
+export function formatError(error: any): string {
+  if (error === null || error === undefined) {
+    return "Error: null or undefined";
+  }
+  try {
+    return JSON.stringify(error, null, 2); // Format JSON with indentation
+  } catch {
+    return String(error); // Fallback for non-JSON errors
+  }
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,9 +37,6 @@ export function isCarRequest(request : Request) {
 }
 
 export function formatError(error: any): string {
-  if (error === null || error === undefined) {
-    return "Error: null or undefined";
-  }
   try {
     return JSON.stringify(error, null, 2); // Format JSON with indentation
   } catch {


### PR DESCRIPTION
I got an error while trying to upload a file using `Console` in my localhost, and pointing to `staging.storage`:
![error-while-adding-new-file-localhost](https://github.com/user-attachments/assets/546270b3-0f48-483b-b006-c193aa156b9e)

As you can see the error output in the Receipt doesn't show the proper message.

I've implemented a minor fix to format the error as json format, and the output will look like this:
![fix-error-message](https://github.com/user-attachments/assets/8351dd69-a260-48f6-9e4e-949131413301)

