### PR TITLE
feat(RequestInspector): add copy functionality for display values in table

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,5 +3,8 @@
   "description": "Inspect UCAN requests",
   "version": "1.0.1",
   "manifest_version": 3,
-  "devtools_page": "devtools.html"
+  "devtools_page": "devtools.html",
+  "permissions": [
+    "clipboardWrite"
+  ]
 }

--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -27,36 +27,42 @@ import CloseIcon from '@mui/icons-material/Close';
 import Tooltip from '@mui/material/Tooltip';
 import Button from '@mui/material/Button';
 import DownloadIcon from '@mui/icons-material/Download';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 
 import { Fragment } from 'react'
 import { Delegation } from "@ucanto/core/delegation";
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
  
-function TableDisplay({ size,  index , children} : React.PropsWithChildren<{size? : "small" | "medium", index : Record<string, React.ReactNode> }>) {
+function TableDisplay({ size,  index , children} : React.PropsWithChildren<{size? : "small" | "medium", index : Record<string, React.ReactNode | { display: ReactNode, copy: string }> }>) {
   return (
       <Table size={size}>
         <TableBody>
           {
             Object.entries(index).map(([heading, value]) => {
+              const isObjectWithCopy = typeof value === 'object' && value !== null && 'display' in (value as any) && 'copy' in (value as any)
+              const displayNode: ReactNode = isObjectWithCopy ? (value as any).display : (value as ReactNode)
+              const copyText: string = isObjectWithCopy
+                ? String((value as any).copy)
+                : typeof value === 'string'
+                  ? value
+                  : typeof value === 'number'
+                    ? String(value)
+                    : ''
+              const handleCopy = () => {
+                if (!copyText) return
+                navigator.clipboard?.writeText(copyText).catch(() => {})
+              }
               return <TableRow key={heading}>
-                <TableCell sx={{
-                  width: '120px',
-                  minWidth: '120px',
-                  fontWeight: 500,
-                }}>{heading}</TableCell>
-                <TableCell sx={{
-                  maxWidth: 0,
-                  width: '100%',
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  '& pre': {
-                    margin: 0,
-                    whiteSpace: 'pre-wrap',
-                    wordBreak: 'break-all',
-                  },
-                }}>{value}</TableCell>
-                <TableCell sx={{ width: '48px', minWidth: '48px' }}></TableCell>
+                <TableCell></TableCell>
+                <TableCell>{heading}</TableCell>
+                <TableCell>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    <span>{displayNode}</span>
+                    <IconButton size="small" aria-label={`Copy ${heading}`} onClick={handleCopy} disabled={!copyText}>
+                      <ContentCopyIcon fontSize="inherit" />
+                    </IconButton>
+                  </Box>
+                </TableCell>
               </TableRow>
             })
           }
@@ -67,9 +73,9 @@ function TableDisplay({ size,  index , children} : React.PropsWithChildren<{size
 }
 
 function CapabilityDisplay({ capability } : { capability: Capability }) {
-  const index : Record<string, React.ReactNode> = Object.assign({
+  const index : Record<string, React.ReactNode | { display: ReactNode, copy: string }> = Object.assign({
     Can: capability.can,
-    With: shortString(capability.with, 60)
+    With: { display: shortString(capability.with, 60), copy: String(capability.with) }
   }, capability.nb ? { NB: JSON.stringify(capability.nb, bigIntSafe, 4) } : {})
   return (
     <TableDisplay size="small" index={index} />
@@ -84,10 +90,10 @@ function ProofDisplay({ proof } : { proof: Proof }) {
   if (isDelegation(proof)) {
     const capabilities = proof.capabilities.map(capability => <CapabilityDisplay capability={capability} />)
     const proofs = proof.proofs.map((proof) => <ProofDisplay proof={proof}/>)
-    const index: Record<string, ReactNode> = {
+    const index: Record<string, ReactNode | { display: ReactNode, copy: string }> = {
       'Root CID': <ShortenAndScroll>{proof.cid.toString()}</ShortenAndScroll>,
-      Issuer: <ShortenAndScroll>{proof.issuer.did()}</ShortenAndScroll>,
-      Audience: <ShortenAndScroll>{proof.audience.did()}</ShortenAndScroll>,
+      Issuer: { display: <ShortenAndScroll>{proof.issuer.did()}</ShortenAndScroll>, copy: proof.issuer.did() },
+      Audience: { display: <ShortenAndScroll>{proof.audience.did()}</ShortenAndScroll>, copy: proof.audience.did() },
       Expiration: proof.expiration.toString(),
     }
     return (
@@ -112,8 +118,8 @@ function InvocationTable({invocation} : { invocation : Invocation }) {
   const capabilities = invocation.capabilities.map((capability) => <CapabilityDisplay capability={capability}/>)
   const proofs = invocation.proofs.map((proof) => <ProofDisplay proof={proof}/>)
   const index = {
-    Issuer: shortString(invocation.issuer.did(), 60),
-    Audience: invocation.audience.did(),
+    Issuer: { display: shortString(invocation.issuer.did(), 60), copy: invocation.issuer.did() },
+    Audience: { display: invocation.audience.did(), copy: invocation.audience.did() },
   }
   return (
     <TableDisplay size="small" index={index}>
@@ -191,10 +197,12 @@ function CollapsableRow({ header, children} : React.PropsWithChildren<{header:st
     </Fragment>
   )
 }
-
+ 
 function ReceiptDisplay({receipt, expanded = false} : { receipt : Receipt, expanded : boolean }) {
-  const index = {
-    Out: receipt.out.ok ? <pre>{JSON.stringify(receipt.out.ok, bigIntSafe, 2)}</pre> : `Error: ${formatError(receipt.out.error)}`,
+  const index: Record<string, ReactNode | { display: ReactNode, copy: string }> = {
+    Out: receipt.out.ok
+      ? { display: <pre>{JSON.stringify(receipt.out.ok, bigIntSafe, 2)}</pre>, copy: JSON.stringify(receipt.out.ok, bigIntSafe, 2) }
+      : `Error: ${formatError(receipt.out.error)}`,
   }
   return (
     <Accordion defaultExpanded={expanded}>
@@ -220,8 +228,14 @@ function ReceiptDisplay({receipt, expanded = false} : { receipt : Receipt, expan
           :
             <TableRow>
               <TableCell>Ran</TableCell>
-              <TableCell>{receipt.ran.toString()}</TableCell>
-              <TableCell></TableCell>
+              <TableCell>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <span>{receipt.ran.toString()}</span>
+                  <IconButton size="small" aria-label={`Copy Ran`} onClick={() => navigator.clipboard?.writeText(receipt.ran.toString()).catch(() => {})}>
+                    <ContentCopyIcon fontSize="inherit" />
+                  </IconButton>
+                </Box>
+              </TableCell>
             </TableRow>
           }
         </TableDisplay>

--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -53,15 +53,27 @@ function TableDisplay({ size,  index , children} : React.PropsWithChildren<{size
                 navigator.clipboard?.writeText(copyText).catch(() => {})
               }
               return <TableRow key={heading}>
-                <TableCell></TableCell>
-                <TableCell>{heading}</TableCell>
-                <TableCell>
-                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                    <span>{displayNode}</span>
-                    <IconButton size="small" aria-label={`Copy ${heading}`} onClick={handleCopy} disabled={!copyText}>
-                      <ContentCopyIcon fontSize="inherit" />
-                    </IconButton>
-                  </Box>
+                <TableCell sx={{
+                  width: '120px',
+                  minWidth: '120px',
+                  fontWeight: 500,
+                }}>{heading}</TableCell>
+                <TableCell sx={{
+                  maxWidth: 0,
+                  width: '100%',
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                  '& pre': {
+                    margin: 0,
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-all',
+                  },
+                }}>{displayNode}</TableCell>
+                <TableCell sx={{ width: '48px', minWidth: '48px' }}>
+                  <IconButton size="small" aria-label={`Copy ${heading}`} onClick={handleCopy} disabled={!copyText}>
+                    <ContentCopyIcon fontSize="inherit" />
+                  </IconButton>
                 </TableCell>
               </TableRow>
             })
@@ -197,7 +209,6 @@ function CollapsableRow({ header, children} : React.PropsWithChildren<{header:st
     </Fragment>
   )
 }
- 
 function ReceiptDisplay({receipt, expanded = false} : { receipt : Receipt, expanded : boolean }) {
   const index: Record<string, ReactNode | { display: ReactNode, copy: string }> = {
     Out: receipt.out.ok
@@ -236,6 +247,7 @@ function ReceiptDisplay({receipt, expanded = false} : { receipt : Receipt, expan
                   </IconButton>
                 </Box>
               </TableCell>
+              <TableCell></TableCell>
             </TableRow>
           }
         </TableDisplay>

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,0 +1,46 @@
+import IconButton from '@mui/material/IconButton'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+
+export default function CopyButton({ value, ariaLabel, size = 'small' }: { value: string, ariaLabel?: string, size?: 'small' | 'medium' | 'large' }) {
+  const fallbackCopy = (text: string) => {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.setAttribute('readonly', '')
+    textarea.style.position = 'fixed'
+    textarea.style.left = '-9999px'
+    document.body.appendChild(textarea)
+    textarea.focus()
+    textarea.select()
+    try {
+      document.execCommand('copy')
+    } finally {
+      document.body.removeChild(textarea)
+    }
+  }
+
+  const handleCopy = async () => {
+    if (!value) return
+    const isDevtools = typeof chrome !== 'undefined' && (chrome as any).devtools
+    if (isDevtools) {
+      fallbackCopy(value)
+      return
+    }
+    try {
+      if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+        await navigator.clipboard.writeText(value)
+        return
+      }
+    } catch {
+      // ignore and use fallback
+    }
+    fallbackCopy(value)
+  }
+
+  return (
+    <IconButton size={size} aria-label={ariaLabel ?? 'Copy'} onClick={handleCopy} disabled={!value}>
+      <ContentCopyIcon fontSize="inherit" />
+    </IconButton>
+  )
+}
+
+


### PR DESCRIPTION
- Add copy buttons next to field values rendered by `TableDisplay` in `src/RequestInspector.tsx`.
- Extend `TableDisplay` to accept `{ display, copy }` entries and copy via `navigator.clipboard`.
- Wire copy for issuer/audience DIDs, capability `with`, receipt `Out`, and non-delegation `Ran`.

Closes #10 