### PR TITLE
feat(RequestInspector): add close button to RequestInspector for closing request detail panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ucan-chrome-ext",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ucan-chrome-ext",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "devDependencies": {
         "@emotion/react": "^11.11.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,7 +79,10 @@ function App() {
             flex: "1 1 50%",
           }}>
             
-              <RequestInspector request={selectedRequest}/>
+              <RequestInspector 
+                request={selectedRequest}
+                onClose={() => selectRequest(null)}
+              />
           </Box>  : ''
         }
       </Box>

--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -23,6 +23,8 @@ import IconButton from '@mui/material/IconButton';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import Paper from '@mui/material/Paper'
+import CloseIcon from '@mui/icons-material/Close';
+import Tooltip from '@mui/material/Tooltip';
 
 import { Fragment } from 'react'
 import { Delegation } from "@ucanto/core/delegation";
@@ -275,7 +277,7 @@ function CustomTabPanel(props: TabPanelProps) {
   );
 }
 
-function RequestInspector({request} : {request: Request}) {
+function RequestInspector({request, onClose} : {request: Request, onClose: () => void}) {
   const [tabIndex, setTabIndex] = useState(0)
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
@@ -285,7 +287,12 @@ function RequestInspector({request} : {request: Request}) {
   return (
     <Paper sx={{ height: "100%", overflowY: "scroll" }} elevation={3}>
     <Box sx={{ width: '100%' }}>
-      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider', display: 'flex', alignItems: 'center' }}>
+        <Tooltip title="Close panel">
+          <IconButton onClick={onClose}>
+            <CloseIcon />
+          </IconButton>
+        </Tooltip>
         <Tabs value={tabIndex} onChange={handleChange} aria-label="basic tabs example">
           <Tab label="Request" {...a11yProps(0)} />
           <Tab label="Response" {...a11yProps(1)} />


### PR DESCRIPTION
- Added close button to RequestInspector header  
- Clicking the button clears the selected request and closes the request detail panel  
- Added "Close panel" tooltip for accessibility  

closes #12
