### PR TITLE
feat: add UCAN fact field visualization with dag-json support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,16 @@ Sometimes it doesn't show up immediately -- if this is the case, I recommend clo
 
 # What you should see
 
-Once the developer tools are open, any requests that sent that are in UCAN format should show up in the list on the `UCan Requests` tab. Note just like the network tab, requests only show up if they initiate after you open developer tools, so you may have to reload the page
+Once the developer tools are open, any requests that sent that are in UCAN format should show up in the list on the `UCan Requests` tab. Note just like the network tab, requests only show up if they initiate after you open developer tools, so you may have to reload the page.
+
+## UCAN Field Visualization
+
+The extension provides detailed visualization of UCAN fields:
+
+- **Capabilities**: Shows the 'can' and 'with' fields for each capability
+- **Fact Field**: If a capability contains a fact field, it will be displayed in a human-readable JSON format using DAG-JSON encoding
+- **Proofs**: Displays the full chain of proofs with their capabilities
+- **Receipts**: Shows the output and execution details of UCAN operations
 
 # Developing
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react-dom": "^18.3.0",
     "@ucanto/core": "^10.0.1",
     "@ucanto/transport": "^9.1.1",
+    "@ipld/dag-json": "^10.1.5",
     "browser-sync": "^2.27.10",
     "browser-sync-webpack-plugin": "^2.3.0",
     "copy-webpack-plugin": "^11.0.0",

--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, ReactNode } from "react"
 import { AgentMessage, Invocation, Receipt, Capability, Proof, Delegation as DelegationType} from "@ucanto/interface"
 import { isDelegation} from '@ucanto/core'
 import { Request, isChromeRequest } from './types'
+import * as dagJson from '@ipld/dag-json'
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';
@@ -49,7 +50,21 @@ function CapabilityDisplay({ capability } : { capability: Capability }) {
   const index : Record<string, React.ReactNode> = Object.assign({
     Can: capability.can,
     With: shortString(capability.with, 60)
-  }, capability.nb ? { NB: JSON.stringify(capability.nb, bigIntSafe, 4) } : {})
+  }, 
+  capability.nb ? { NB: JSON.stringify(capability.nb, bigIntSafe, 4) } : {})
+
+  const withObj = capability.with as any
+  if (withObj && typeof withObj === 'object' && 'fact' in withObj) {
+    try {
+      const factValue = dagJson.decode(dagJson.encode(withObj.fact))
+      Object.assign(index, {
+        Fact: <pre style={{ margin: 0 }}>{JSON.stringify(factValue, bigIntSafe, 2)}</pre>
+      })
+    } catch (err) {
+      console.warn('Failed to encode/decode fact field:', err)
+    }
+  }
+
   return (
     <TableDisplay size="small" index={index} />
   )

--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -82,6 +82,7 @@ function ProofDisplay({ proof } : { proof: Proof }) {
       Issuer: <ShortenAndScroll>{proof.issuer.did()}</ShortenAndScroll>,
       Audience: <ShortenAndScroll>{proof.audience.did()}</ShortenAndScroll>,
       Expiration: proof.expiration.toString(),
+      ...(proof.facts && { Facts: <pre>{JSON.stringify(proof.facts, null, 2)}</pre> })
     }
     return (
       <TableDisplay size="small" index={index}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
 export type Request = chrome.devtools.network.Request | chrome.devtools.network.HAREntry
 
 export const isChromeRequest = (request: Request) : request is chrome.devtools.network.Request => (typeof (request as chrome.devtools.network.Request).getContent === 'function')
+
+declare module '@ucanto/interface' {
+  interface With {
+    fact?: unknown
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,8 +2,10 @@ export type Request = chrome.devtools.network.Request | chrome.devtools.network.
 
 export const isChromeRequest = (request: Request) : request is chrome.devtools.network.Request => (typeof (request as chrome.devtools.network.Request).getContent === 'function')
 
+import type { Fact } from '@ucanto/interface'
+
 declare module '@ucanto/interface' {
-  interface With {
-    fact?: unknown
+  interface Delegation<C> {
+    facts: Fact[]
   }
 }


### PR DESCRIPTION
closes issue #16  

Adds support for visualizing UCAN fact fields in a human-readable format using DAG-JSON encoding.

## Changes
- Added `@ipld/dag-json` package for proper JSON encoding/decoding
- Implemented fact field visualization in the CapabilityDisplay component
- Added type definitions for UCAN fact field in `@ucanto/interface`
- Updated documentation with fact field visualization details