### PR TITLE
feat(fact): add fact visualisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
+        "@ipld/dag-json": "^10.1.5",
         "@mui/icons-material": "^5.15.20",
         "@mui/material": "^5.15.20",
         "@types/chrome": "^0.0.193",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@ipld/dag-json": "^10.1.5",
     "@types/chrome": "^0.0.193",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, ReactNode } from "react"
 import { AgentMessage, Invocation, Receipt, Capability, Proof, Delegation as DelegationType} from "@ucanto/interface"
 import { isDelegation} from '@ucanto/core'
 import { Request, isChromeRequest } from './types'
+import * as DagJSON from '@ipld/dag-json'
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';
@@ -76,6 +77,9 @@ function ProofDisplay({ proof } : { proof: Proof }) {
         <CollapsableRow header="Proofs">
           {proofs}
         </CollapsableRow>
+        <CollapsableRow header="Facts">
+          <FactDisplay facts={proof.facts} />
+        </CollapsableRow>
       </TableDisplay>
     )
   } else {
@@ -83,6 +87,42 @@ function ProofDisplay({ proof } : { proof: Proof }) {
       <pre>{JSON.stringify(proof, null, 2)}</pre>
     )
   }
+}
+
+function FactDisplay({ facts } : { facts: any[] }) {
+  if (facts.length === 0) {
+    return <div style={{fontStyle: 'italic', color: '#666'}}>No facts</div>
+  }
+  
+  const formatFact = (fact: any) => {
+    try {
+      const dagJsonString = DagJSON.stringify(fact)
+      return JSON.stringify(JSON.parse(dagJsonString), null, 2)
+    } catch {
+      return JSON.stringify(fact, bigIntSafe, 2)
+    }
+  }
+  
+  return (
+    <div>
+      {facts.map((fact, index) => (
+        <div key={index} style={{marginBottom: '8px'}}>
+          <div style={{fontWeight: 'bold', marginBottom: '4px'}}>Fact {index + 1}:</div>
+          <pre style={{
+            backgroundColor: '#f5f5f5', 
+            padding: '8px', 
+            borderRadius: '4px',
+            overflow: 'auto',
+            fontSize: '12px',
+            margin: 0,
+            fontFamily: 'Monaco, Consolas, "Lucida Console", monospace'
+          }}>
+            {formatFact(fact)}
+          </pre>
+        </div>
+      ))}
+    </div>
+  )
 }
 
 function InvocationTable({invocation} : { invocation : Invocation }) {


### PR DESCRIPTION
This PR implements the visualization of UCAN 'fct' (facts) field in Proof.

Changes:
- Added `FactDisplay` component to render facts in a readable, formatted JSON layout.
- Integrated `FactDisplay` inside `Proof` under a "Facts" collapsible row.
- Supports single or multiple facts, with DAG-JSON decoding via @ipld/dag-json.

**Screenshot:**
<img width="1905" height="800" alt="Screenshot from 2025-08-23 04-59-09" src="https://github.com/user-attachments/assets/9f5551f7-c1af-47f0-b628-c7ae49b6f46e" />


Closes: #16 
