### PR TITLE
feat(devtools): add sessions, request tagging, and related-request ch…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,12 @@ import IconButton from '@mui/material/IconButton';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import { useTheme } from './ThemeContext';
+import Button from '@mui/material/Button'
+import ButtonGroup from '@mui/material/ButtonGroup'
+import TextField from '@mui/material/TextField'
+import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import { getInvocationFingerprint, getRequestKey } from './util'
 
 type SetAction = {
   action: "set",
@@ -34,12 +40,17 @@ function App() {
   const { isDarkMode, toggleTheme } = useTheme();
   const [requests, dispatch] = useReducer(reducer, [])
   const [selectedRequest, selectRequest] = useState<Request | null>(null)
+  const [sessions, setSessions] = useState<Record<string, Request[]>>({ default: [] })
+  const [currentSessionId, setCurrentSessionId] = useState<string>('default')
+  const [tagsByRequestKey, setTagsByRequestKey] = useState<Record<string, string[]>>({})
+  const [newSessionName, setNewSessionName] = useState<string>("")
   useEffect(() => {
     let ignore = false
     dispatch({action: "set", requests: []})
     chrome.devtools.network.getHAR((harLog) => {
       if (!ignore) {
         dispatch({ action: "set", requests: harLog.entries})
+        setSessions((prev) => ({ ...prev, [currentSessionId]: harLog.entries }))
       }
     })
     return () => {
@@ -53,6 +64,7 @@ function App() {
       const shouldPersist = stored ? JSON.parse(stored) : false
       if (!shouldPersist) {
         dispatch({ action: 'set', requests: [] })
+        setSessions((prev) => ({ ...prev, [currentSessionId]: [] }))
         selectRequest(null)
       }
     }
@@ -63,12 +75,55 @@ function App() {
   }, [])
   
   useEffect(() => {
-    const listener = (request : chrome.devtools.network.Request) => { dispatch({action: "increment", request}) }
+    const listener = (request : chrome.devtools.network.Request) => {
+      dispatch({action: "increment", request})
+      setSessions((prev) => {
+        const next = { ...prev }
+        const list = next[currentSessionId] || []
+        next[currentSessionId] = [...list, request]
+        return next
+      })
+    }
     chrome.devtools.network.onRequestFinished.addListener(listener)
     return () => {
       chrome.devtools.network.onRequestFinished.removeListener(listener)
     }
   })
+
+  const createSession = () => {
+    const name = newSessionName.trim() || `session-${Object.keys(sessions).length + 1}`
+    if (sessions[name]) {
+      setCurrentSessionId(name)
+      return
+    }
+    setSessions((prev) => ({ ...prev, [name]: [] }))
+    setCurrentSessionId(name)
+    setNewSessionName("")
+  }
+
+  const switchSession = (id: string) => {
+    setCurrentSessionId(id)
+    const list = sessions[id] || []
+    dispatch({ action: 'set', requests: list })
+    selectRequest(null)
+  }
+
+  const addTag = (request: Request, tag: string) => {
+    const key = getRequestKey(request)
+    setTagsByRequestKey((prev) => {
+      const existing = prev[key] || []
+      if (existing.includes(tag)) return prev
+      return { ...prev, [key]: [...existing, tag] }
+    })
+  }
+
+  const removeTag = (request: Request, tag: string) => {
+    const key = getRequestKey(request)
+    setTagsByRequestKey((prev) => {
+      const existing = prev[key] || []
+      return { ...prev, [key]: existing.filter(t => t !== tag) }
+    })
+  }
 
   return (
     <Box sx={{
@@ -78,11 +133,27 @@ function App() {
     }}>
       <Box sx={{
         display: 'flex',
-        justifyContent: 'flex-end',
+        alignItems: 'center',
+        justifyContent: 'space-between',
         p: 1,
         borderBottom: 1,
         borderColor: 'divider'
       }}>
+        <Stack direction="row" spacing={1} alignItems="center">
+          <Typography variant="body2">Sessions:</Typography>
+          <ButtonGroup size="small" variant="outlined">
+            {Object.keys(sessions).map((id) => (
+              <Button key={id} onClick={() => switchSession(id)} variant={id === currentSessionId ? 'contained' : 'outlined'}>{id}</Button>
+            ))}
+          </ButtonGroup>
+          <TextField
+            size="small"
+            placeholder="New session name"
+            value={newSessionName}
+            onChange={(e) => setNewSessionName(e.target.value)}
+          />
+          <Button size="small" variant="contained" onClick={createSession}>Create</Button>
+        </Stack>
         <IconButton onClick={toggleTheme} color="inherit">
           {isDarkMode ? <Brightness7Icon /> : <Brightness4Icon />}
         </IconButton>
@@ -110,13 +181,24 @@ function App() {
             requests={requests}
             selectedRequest={selectedRequest}
             selectRequest={selectRequest}
+            tagsByRequestKey={tagsByRequestKey}
+            onAddTag={addTag}
+            onRemoveTag={removeTag}
           />
         </Box>
         {selectedRequest ? (
           <Box sx={{
             flex: "1 1 50%",
           }}>
-            <RequestInspector request={selectedRequest} onClose={() => selectRequest(null)}/>
+            <RequestInspector 
+              request={selectedRequest} 
+              onClose={() => selectRequest(null)}
+              getRelated={(r) => {
+                const fp = getInvocationFingerprint(r)
+                if (!fp) return []
+                return requests.filter((q) => getInvocationFingerprint(q) === fp)
+              }}
+            />
           </Box>
         ) : null}
       </Box>

--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -9,6 +9,10 @@ import Card from '@mui/material/Card'
 import CardHeader from '@mui/material/CardHeader';
 import CardContent from '@mui/material/CardContent';
 import {shortString, bigIntSafe, messageFromRequest, decodeMessage, formatError, getRequestStatus, getStatusColor} from './util'
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import ListItemButton from '@mui/material/ListItemButton'
+import ListItemText from '@mui/material/ListItemText'
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
@@ -406,9 +410,10 @@ function CustomTabPanel(props: TabPanelProps) {
   );
 }
 
-function RequestInspector({request, onClose} : {request: Request, onClose: () => void}) {
+function RequestInspector({request, onClose, getRelated} : {request: Request, onClose: () => void, getRelated?: (r: Request) => Request[]}) {
   const [tabIndex, setTabIndex] = useState(0)
   const status = getRequestStatus(request);
+  const related = getRelated ? getRelated(request) : []
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setTabIndex(newValue);
@@ -437,6 +442,28 @@ function RequestInspector({request, onClose} : {request: Request, onClose: () =>
       </Box>
       <CustomTabPanel value={tabIndex} index={0}>
         <RequestDisplay request={request}/> 
+        {related.length > 0 && (
+          <Card sx={{ mt: 2 }}>
+            <CardHeader 
+              title="Related Requests"
+              sx={{
+                py: 1,
+                '& .MuiCardHeader-title': {
+                  fontSize: '1rem',
+                },
+              }}
+            />
+            <CardContent sx={{ py: 0 }}>
+              <List dense>
+                {related.map((r, idx) => (
+                  <ListItem key={idx} disablePadding>
+                    <ListItemText primary={r.request.url} secondary={`HTTP ${r.response.status}`} />
+                  </ListItem>
+                ))}
+              </List>
+            </CardContent>
+          </Card>
+        )}
       </CustomTabPanel> 
       <CustomTabPanel value={tabIndex} index={1}>
         <ResponseDisplay request={request} />

--- a/src/RequestList.tsx
+++ b/src/RequestList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Request, isChromeRequest } from "./types"
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
@@ -9,14 +9,19 @@ import TableRow from '@mui/material/TableRow';
 import Box from '@mui/material/Box';
 import Switch from '@mui/material/Switch';
 import FormControlLabel from '@mui/material/FormControlLabel';
-import { isCarRequest, messageFromRequest, getRequestStatus, getStatusColor, getRequestTiming, formatTiming } from "./util";
+import { isCarRequest, messageFromRequest, getRequestStatus, getStatusColor, getRequestTiming, formatTiming, getRequestKey } from "./util";
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+import Chip from '@mui/material/Chip'
+import TextField from '@mui/material/TextField'
 
-function RequestEntry({ request, selectedRequest, selectRequest } : {request: Request, selectedRequest: Request | null, selectRequest: (request: Request) => void}) {
+function RequestEntry({ request, selectedRequest, selectRequest, tagsByRequestKey, onAddTag, onRemoveTag } : {request: Request, selectedRequest: Request | null, selectRequest: (request: Request) => void, tagsByRequestKey: Record<string, string[]>, onAddTag: (r: Request, tag: string) => void, onRemoveTag: (r: Request, tag: string) => void}) {
   const message = messageFromRequest(request)
   const status = getRequestStatus(request);
   const timing = getRequestTiming(request)
   const formattedTiming = formatTiming(timing)
+  const requestKey = getRequestKey(request)
+  const tags = tagsByRequestKey[requestKey] || []
+  const [newTag, setNewTag] = useState("")
   
   return (
     <TableRow onClick={() => selectRequest(request)} hover selected={request === selectedRequest}>
@@ -46,18 +51,52 @@ function RequestEntry({ request, selectedRequest, selectRequest } : {request: Re
         { typeof message === 'string' ? message : message.invocations.flatMap((invocation) => invocation.capabilities.map((capability => capability.can))).join(", ")}
       </TableCell>
       <TableCell>{formattedTiming}</TableCell>
+      <TableCell>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5, flexWrap: 'wrap' }} onClick={(e) => e.stopPropagation()}>
+          {tags.map((t) => (
+            <Chip key={t} label={t} size="small" onDelete={() => onRemoveTag(request, t)} />
+          ))}
+          <TextField 
+            size="small" 
+            placeholder="+tag" 
+            value={newTag} 
+            onChange={(e) => setNewTag(e.target.value)} 
+            onClick={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                const v = newTag.trim()
+                if (v) {
+                  onAddTag(request, v)
+                  setNewTag("")
+                }
+              }
+            }}
+            sx={{ width: 80 }}
+          />
+        </Box>
+      </TableCell>
     </TableRow>
   )
 }
 
-function RequestList({ requests, selectedRequest, selectRequest } : { requests: Request[], selectedRequest: Request | null, selectRequest: (request: Request) => void }) {
+function RequestList({ requests, selectedRequest, selectRequest, tagsByRequestKey, onAddTag, onRemoveTag } : { requests: Request[], selectedRequest: Request | null, selectRequest: (request: Request) => void, tagsByRequestKey: Record<string, string[]>, onAddTag: (r: Request, tag: string) => void, onRemoveTag: (r: Request, tag: string) => void }) {
   const defaultChecked = JSON.parse(localStorage.getItem('persistOnReload') || 'false')
 
   const handlePersistChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     localStorage.setItem('persistOnReload', JSON.stringify(e.target.checked))
   }
 
-  const requestItems = requests.filter(isCarRequest).map((request, idx) => <RequestEntry key={`${request.request.url}-${idx}`} selectedRequest={selectedRequest} selectRequest={selectRequest} request={request} />)
+  const requestItems = requests.filter(isCarRequest).map((request, idx) => (
+    <RequestEntry 
+      key={`${request.request.url}-${idx}`}
+      selectedRequest={selectedRequest}
+      selectRequest={selectRequest}
+      request={request}
+      tagsByRequestKey={tagsByRequestKey}
+      onAddTag={onAddTag}
+      onRemoveTag={onRemoveTag}
+    />
+  ))
   return (
     <TableContainer sx={{height: "100%", overflowY: "scroll"}}>
     <Box sx={{ display: 'flex', justifyContent: 'flex-end', px: 2, py: 1 }}>
@@ -82,6 +121,7 @@ function RequestList({ requests, selectedRequest, selectRequest } : { requests: 
           <TableCell>URL</TableCell>
           <TableCell>Capabilities</TableCell>
           <TableCell><abbr title="Round Trip Time">RTT</abbr></TableCell>
+          <TableCell>Tags</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>

--- a/src/util.ts
+++ b/src/util.ts
@@ -128,3 +128,42 @@ export function formatTiming(timeMs: number | null): string {
   
   return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`;
 }
+
+export function getRequestOrigin(request: Request): string {
+  try {
+    const url = new URL(request.request.url)
+    return url.origin
+  } catch {
+    return ''
+  }
+}
+
+export function getInvocationFingerprint(request: Request): string | null {
+  const message = messageFromRequest(request)
+  if (typeof message === 'string') return null
+  if (!message || message.invocations.length === 0) return null
+  const first = message.invocations[0]
+  const caps = first.capabilities.map(c => `${c.can}:${typeof c.with === 'string' ? c.with : String(c.with)}`).join('|')
+  return `${caps}`
+}
+
+export function getRequestStartTimeMs(request: Request): number | null {
+  const har = request as chrome.devtools.network.HAREntry
+  if (har && (har as any).startedDateTime) {
+    const t = Date.parse((har as any).startedDateTime)
+    return isNaN(t) ? null : t
+  }
+  const dev = request as chrome.devtools.network.Request
+  if (dev && (dev as any).startedDateTime) {
+    const t = Date.parse((dev as any).startedDateTime)
+    return isNaN(t) ? null : t
+  }
+  return null
+}
+
+export function getRequestKey(request: Request): string {
+  const url = request.request.url
+  const status = request.response?.status ?? 0
+  const start = getRequestStartTimeMs(request) ?? 0
+  return `${url}#${status}#${start}`
+}


### PR DESCRIPTION
Closes #50 

Introduce sessions, request tagging, and related-request chains to organize UCAN traffic

This change adds a comprehensive request-organization workflow to the DevTools panel:
- Sessions: Capture requests into named sessions; create/switch sessions from the header.
- Tags: Add/remove per-request tags via a lightweight chip UI in the list.
- Related chains: Visualize related UCAN requests in the inspector based on invocation fingerprints.

Motivation
- Debugging UCAN flows often involves multiple related requests; grouping them into sessions and surfacing related chains reduces cognitive load.
- Tags enable quick ad-hoc annotation (e.g., “happy-path”, “retry”, “edge-case”).
- Chain visualization helps correlate invocations/receipts across requests.