### PR TITLE
Add JSON pretty print and copy to clipboard functionality

### DIFF
--- a/src/CopyButton.tsx
+++ b/src/CopyButton.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import IconButton from '@mui/material/IconButton';
+import Tooltip from '@mui/material/Tooltip';
+import ContentCopyIcon from '@mui/icons-material/ContentCopy';
+import CheckIcon from '@mui/icons-material/Check';
+
+interface CopyButtonProps {
+  text: string;
+  tooltip?: string;
+  size?: 'small' | 'medium' | 'large';
+}
+
+export const CopyButton: React.FC<CopyButtonProps> = ({ 
+  text, 
+  tooltip = 'Copy to clipboard',
+  size = 'small' 
+}) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    
+    try {
+      
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+        return;
+      }
+      
+      const textArea = document.createElement('textarea');
+      textArea.value = text;
+      textArea.style.position = 'fixed';
+      textArea.style.left = '-999999px';
+      textArea.style.top = '-999999px';
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+      
+      try {
+        const successful = document.execCommand('copy');
+        if (successful) {
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        } else {
+          console.error('Copy command failed');
+        }
+      } catch (err) {
+        console.error('Failed to copy using execCommand:', err);
+      } finally {
+        document.body.removeChild(textArea);
+      }
+      
+    } catch (err) {
+      console.error('Failed to copy:', err);
+      
+      if (typeof chrome !== 'undefined' && chrome.devtools) {
+        try {
+          const input = document.createElement('input');
+          input.value = text;
+          input.style.position = 'absolute';
+          input.style.left = '-9999px';
+          document.body.appendChild(input);
+          input.select();
+          document.execCommand('copy');
+          document.body.removeChild(input);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        } catch (chromeErr) {
+          console.error('Chrome DevTools copy failed:', chromeErr);
+        }
+      }
+    }
+  };
+
+  return (
+    <Tooltip title={copied ? 'Copied!' : tooltip}>
+      <IconButton
+        onClick={handleCopy}
+        size={size}
+        color={copied ? 'success' : 'default'}
+        sx={{ ml: 1 }}
+      >
+        {copied ? <CheckIcon fontSize="small" /> : <ContentCopyIcon fontSize="small" />}
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/src/JsonViewer.tsx
+++ b/src/JsonViewer.tsx
@@ -1,0 +1,110 @@
+import React, { useState } from 'react';
+import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import Tooltip from '@mui/material/Tooltip';
+import { useTheme } from '@mui/material/styles';
+import { CopyButton } from './CopyButton';
+
+interface JsonViewerProps {
+  data: any;
+  expanded?: boolean;
+  showCopy?: boolean;
+  maxHeight?: string | number;
+}
+
+export const JsonViewer: React.FC<JsonViewerProps> = ({ 
+  data, 
+  expanded = true,
+  showCopy = true,
+  maxHeight = '400px'
+}) => {
+  const [isExpanded, setIsExpanded] = useState(expanded);
+  const theme = useTheme();
+  
+  const jsonString = JSON.stringify(data, (key, value) => 
+    typeof value === 'bigint' ? value.toString() : value, 2
+  );
+
+  const formatJson = (json: string) => {
+    return json
+      .replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?)/g, 
+        (match) => {
+          let cls = 'json-number';
+          if (/^"/.test(match)) {
+            if (/:$/.test(match)) {
+              cls = 'json-key';
+            } else {
+              cls = 'json-string';
+            }
+          } else if (/true|false/.test(match)) {
+            cls = 'json-boolean';
+          } else if (/null/.test(match)) {
+            cls = 'json-null';
+          }
+          return `<span class="${cls}">${match}</span>`;
+        }
+      );
+  };
+
+  const styles = {
+    container: {
+      position: 'relative' as const,
+      backgroundColor: theme.palette.mode === 'dark' ? '#1e1e1e' : '#f5f5f5',
+      borderRadius: '4px',
+      border: `1px solid ${theme.palette.divider}`,
+      fontFamily: 'Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace',
+      fontSize: '12px',
+      lineHeight: '1.5',
+      overflow: 'auto',
+      maxHeight: isExpanded ? maxHeight : '60px',
+      transition: 'max-height 0.3s ease',
+    },
+    pre: {
+      margin: 0,
+      padding: '12px',
+      whiteSpace: 'pre-wrap' as const,
+      wordBreak: 'break-all' as const,
+    },
+    controls: {
+      position: 'absolute' as const,
+      top: '4px',
+      right: '4px',
+      display: 'flex',
+      gap: '4px',
+      backgroundColor: theme.palette.mode === 'dark' ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.9)',
+      borderRadius: '4px',
+      padding: '2px',
+    }
+  };
+
+  return (
+    <Box sx={styles.container}>
+      <Box sx={styles.controls}>
+        {showCopy && (
+          <CopyButton text={jsonString} tooltip="Copy JSON" />
+        )}
+        <Tooltip title={isExpanded ? 'Collapse' : 'Expand'}>
+          <IconButton
+            size="small"
+            onClick={() => setIsExpanded(!isExpanded)}
+          >
+            {isExpanded ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+          </IconButton>
+        </Tooltip>
+      </Box>
+      <pre 
+        style={styles.pre}
+        dangerouslySetInnerHTML={{ __html: formatJson(jsonString) }}
+      />
+      <style>{`
+        .json-key { color: ${theme.palette.mode === 'dark' ? '#9CDCFE' : '#0451a5'}; }
+        .json-string { color: ${theme.palette.mode === 'dark' ? '#CE9178' : '#a31515'}; }
+        .json-number { color: ${theme.palette.mode === 'dark' ? '#B5CEA8' : '#098658'}; }
+        .json-boolean { color: ${theme.palette.mode === 'dark' ? '#569CD6' : '#0000ff'}; }
+        .json-null { color: ${theme.palette.mode === 'dark' ? '#569CD6' : '#0000ff'}; }
+      `}</style>
+    </Box>
+  );
+};

--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -27,17 +27,23 @@ import CloseIcon from '@mui/icons-material/Close';
 import Tooltip from '@mui/material/Tooltip';
 import Button from '@mui/material/Button';
 import DownloadIcon from '@mui/icons-material/Download';
+import { CopyButton } from './CopyButton';
+import { JsonViewer } from './JsonViewer';
 
 import { Fragment } from 'react'
 import { Delegation } from "@ucanto/core/delegation";
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
  
-function TableDisplay({ size,  index , children} : React.PropsWithChildren<{size? : "small" | "medium", index : Record<string, React.ReactNode> }>) {
+function TableDisplay({ size,  index , children} : React.PropsWithChildren<{size? : "small" | "medium", index : Record<string, React.ReactNode | { value: React.ReactNode, copyable?: string }> }>) {
   return (
       <Table size={size}>
         <TableBody>
           {
-            Object.entries(index).map(([heading, value]) => {
+            Object.entries(index).map(([heading, content]) => {
+              const isObject = content && typeof content === 'object' && 'value' in content;
+              const value = isObject ? content.value : content;
+              const copyText = isObject ? content.copyable : null;
+              
               return <TableRow key={heading}>
                 <TableCell sx={{
                   width: '120px',
@@ -55,7 +61,12 @@ function TableDisplay({ size,  index , children} : React.PropsWithChildren<{size
                     whiteSpace: 'pre-wrap',
                     wordBreak: 'break-all',
                   },
-                }}>{value}</TableCell>
+                }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    {value}
+                    {copyText && <CopyButton text={copyText} size="small" />}
+                  </Box>
+                </TableCell>
                 <TableCell sx={{ width: '48px', minWidth: '48px' }}></TableCell>
               </TableRow>
             })
@@ -67,10 +78,10 @@ function TableDisplay({ size,  index , children} : React.PropsWithChildren<{size
 }
 
 function CapabilityDisplay({ capability } : { capability: Capability }) {
-  const index : Record<string, React.ReactNode> = Object.assign({
-    Can: capability.can,
-    With: shortString(capability.with, 60)
-  }, capability.nb ? { NB: JSON.stringify(capability.nb, bigIntSafe, 4) } : {})
+  const index : Record<string, React.ReactNode | { value: React.ReactNode, copyable?: string }> = Object.assign({
+    Can: { value: capability.can, copyable: capability.can },
+    With: { value: shortString(capability.with, 60), copyable: capability.with }
+  }, capability.nb ? { NB: <JsonViewer data={capability.nb} expanded={false} maxHeight="200px" /> } : {})
   return (
     <TableDisplay size="small" index={index} />
   )
@@ -82,13 +93,22 @@ function ShortenAndScroll({children}: {children: ReactNode}){
 
 function ProofDisplay({ proof } : { proof: Proof }) {
   if (isDelegation(proof)) {
-    const capabilities = proof.capabilities.map(capability => <CapabilityDisplay capability={capability} />)
-    const proofs = proof.proofs.map((proof) => <ProofDisplay proof={proof}/>)
-    const index: Record<string, ReactNode> = {
-      'Root CID': <ShortenAndScroll>{proof.cid.toString()}</ShortenAndScroll>,
-      Issuer: <ShortenAndScroll>{proof.issuer.did()}</ShortenAndScroll>,
-      Audience: <ShortenAndScroll>{proof.audience.did()}</ShortenAndScroll>,
-      Expiration: proof.expiration.toString(),
+    const capabilities = proof.capabilities.map((capability, idx) => <CapabilityDisplay key={idx} capability={capability} />)
+    const proofs = proof.proofs.map((proof, idx) => <ProofDisplay key={idx} proof={proof}/>)
+    const index: Record<string, ReactNode | { value: ReactNode, copyable?: string }> = {
+      'Root CID': { 
+        value: <ShortenAndScroll>{proof.cid.toString()}</ShortenAndScroll>,
+        copyable: proof.cid.toString()
+      },
+      Issuer: { 
+        value: <ShortenAndScroll>{proof.issuer.did()}</ShortenAndScroll>,
+        copyable: proof.issuer.did()
+      },
+      Audience: { 
+        value: <ShortenAndScroll>{proof.audience.did()}</ShortenAndScroll>,
+        copyable: proof.audience.did()
+      },
+      Expiration: proof.expiration ? proof.expiration.toString() : 'Never',
     }
     return (
       <TableDisplay size="small" index={index}>
@@ -101,19 +121,28 @@ function ProofDisplay({ proof } : { proof: Proof }) {
       </TableDisplay>
     )
   } else {
-    const index: Record<string, ReactNode> = {
-      'Root CID': <ShortenAndScroll>{proof.toString()}</ShortenAndScroll>,
+    const index: Record<string, ReactNode | { value: ReactNode, copyable?: string }> = {
+      'Root CID': { 
+        value: <ShortenAndScroll>{proof.toString()}</ShortenAndScroll>,
+        copyable: proof.toString()
+      },
     }
     return <TableDisplay size="small" index={index} />
   }
 }
 
 function InvocationTable({invocation} : { invocation : Invocation }) {
-  const capabilities = invocation.capabilities.map((capability) => <CapabilityDisplay capability={capability}/>)
-  const proofs = invocation.proofs.map((proof) => <ProofDisplay proof={proof}/>)
+  const capabilities = invocation.capabilities.map((capability, idx) => <CapabilityDisplay key={idx} capability={capability}/>)
+  const proofs = invocation.proofs.map((proof, idx) => <ProofDisplay key={idx} proof={proof}/>)
   const index = {
-    Issuer: shortString(invocation.issuer.did(), 60),
-    Audience: invocation.audience.did(),
+    Issuer: { 
+      value: shortString(invocation.issuer.did(), 60),
+      copyable: invocation.issuer.did()
+    },
+    Audience: { 
+      value: invocation.audience.did(),
+      copyable: invocation.audience.did()
+    },
   }
   return (
     <TableDisplay size="small" index={index}>
@@ -138,9 +167,16 @@ function InvocationDisplay({invocation, expanded = false} : { invocation : Invoc
           '& .MuiAccordionSummary-expandIconWrapper': {
             marginLeft: 'auto',
           },
+          '& .MuiAccordionSummary-content': {
+            display: 'flex',
+            alignItems: 'center',
+          },
         }}
       >
-        { invocation.cid.toString() }
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          { invocation.cid.toString() }
+          <CopyButton text={invocation.cid.toString()} tooltip="Copy CID" />
+        </Box>
       </AccordionSummary>
       <AccordionDetails>
         <TableContainer>
@@ -194,7 +230,11 @@ function CollapsableRow({ header, children} : React.PropsWithChildren<{header:st
 
 function ReceiptDisplay({receipt, expanded = false} : { receipt : Receipt, expanded : boolean }) {
   const index = {
-    Out: receipt.out.ok ? <pre>{JSON.stringify(receipt.out.ok, bigIntSafe, 2)}</pre> : `Error: ${formatError(receipt.out.error)}`,
+    Out: receipt.out.ok ? 
+      <JsonViewer data={receipt.out.ok} expanded={true} /> : 
+      <Box sx={{ color: 'error.main' }}>
+        Error: <JsonViewer data={receipt.out.error} expanded={false} />
+      </Box>,
   }
   return (
     <Accordion defaultExpanded={expanded}>
@@ -206,9 +246,16 @@ function ReceiptDisplay({receipt, expanded = false} : { receipt : Receipt, expan
           '& .MuiAccordionSummary-expandIconWrapper': {
             marginLeft: 'auto',
           },
+          '& .MuiAccordionSummary-content': {
+            display: 'flex',
+            alignItems: 'center',
+          },
         }}
       >
-        { receipt.link().toString() }
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          { receipt.link().toString() }
+          <CopyButton text={receipt.link().toString()} tooltip="Copy Receipt Link" />
+        </Box>
       </AccordionSummary>
       <AccordionDetails>
         <TableContainer>
@@ -219,9 +266,14 @@ function ReceiptDisplay({receipt, expanded = false} : { receipt : Receipt, expan
             </CollapsableRow>
           :
             <TableRow>
-              <TableCell>Ran</TableCell>
-              <TableCell>{receipt.ran.toString()}</TableCell>
-              <TableCell></TableCell>
+              <TableCell sx={{ width: '120px', minWidth: '120px', fontWeight: 500 }}>Ran</TableCell>
+              <TableCell sx={{ maxWidth: 0, width: '100%' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                  {receipt.ran.toString()}
+                  <CopyButton text={receipt.ran.toString()} />
+                </Box>
+              </TableCell>
+              <TableCell sx={{ width: '48px', minWidth: '48px' }}></TableCell>
             </TableRow>
           }
         </TableDisplay>


### PR DESCRIPTION
Closes #54 

Add JSON pretty print and copy to clipboard functionality

- Add CopyButton component with multi-method clipboard fallback
- Implement JsonViewer with syntax highlighting and expand/collapse
- Add copy buttons to all relevant fields (CIDs, DIDs, capabilities)
- Replace plain JSON display with formatted JsonViewer in receipts
- Support dark/light theme for JSON syntax highlighting
- Handle BigInt serialization in JSON display
- Use execCommand fallback for Chrome extension compatibility

Enhances developer experience with better JSON readability and quick copy functionality for debugging