### PR TITLE
Add request annotation system with notes, colors, and pinning

### DIFF
--- a/src/AnnotationContext.tsx
+++ b/src/AnnotationContext.tsx
@@ -1,0 +1,85 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react'
+import { Request, RequestAnnotation } from './types'
+
+interface AnnotationContextType {
+  annotations: Map<string, RequestAnnotation>
+  getAnnotation: (requestId: string) => RequestAnnotation | undefined
+  setAnnotation: (requestId: string, annotation: RequestAnnotation) => void
+  deleteAnnotation: (requestId: string) => void
+  clearAllAnnotations: () => void
+}
+
+const AnnotationContext = createContext<AnnotationContextType | undefined>(undefined)
+
+export const useAnnotations = () => {
+  const context = useContext(AnnotationContext)
+  if (!context) {
+    throw new Error('useAnnotations must be used within an AnnotationProvider')
+  }
+  return context
+}
+
+export const getRequestId = (request: Request): string => {
+  return `${request.request.url}-${request.startedDateTime || request.time || Date.now()}`
+}
+
+interface AnnotationProviderProps {
+  children: ReactNode
+}
+
+export function AnnotationProvider({ children }: AnnotationProviderProps) {
+  const [annotations, setAnnotations] = useState<Map<string, RequestAnnotation>>(new Map())
+
+  useEffect(() => {
+    const stored = localStorage.getItem('ucan-request-annotations')
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored)
+        setAnnotations(new Map(Object.entries(parsed)))
+      } catch (e) {
+        console.error('Failed to load annotations:', e)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    const obj = Object.fromEntries(annotations)
+    localStorage.setItem('ucan-request-annotations', JSON.stringify(obj))
+  }, [annotations])
+
+  const getAnnotation = (requestId: string) => {
+    return annotations.get(requestId)
+  }
+
+  const setAnnotation = (requestId: string, annotation: RequestAnnotation) => {
+    setAnnotations(prev => {
+      const next = new Map(prev)
+      next.set(requestId, annotation)
+      return next
+    })
+  }
+
+  const deleteAnnotation = (requestId: string) => {
+    setAnnotations(prev => {
+      const next = new Map(prev)
+      next.delete(requestId)
+      return next
+    })
+  }
+
+  const clearAllAnnotations = () => {
+    setAnnotations(new Map())
+  }
+
+  return (
+    <AnnotationContext.Provider value={{
+      annotations,
+      getAnnotation,
+      setAnnotation,
+      deleteAnnotation,
+      clearAllAnnotations,
+    }}>
+      {children}
+    </AnnotationContext.Provider>
+  )
+}

--- a/src/AnnotationManager.tsx
+++ b/src/AnnotationManager.tsx
@@ -1,0 +1,172 @@
+import React, { useState, useEffect } from 'react'
+import { Request, RequestAnnotation, RequestColor, RequestStatus } from './types'
+import Dialog from '@mui/material/Dialog'
+import DialogTitle from '@mui/material/DialogTitle'
+import DialogContent from '@mui/material/DialogContent'
+import DialogActions from '@mui/material/DialogActions'
+import TextField from '@mui/material/TextField'
+import Button from '@mui/material/Button'
+import ToggleButton from '@mui/material/ToggleButton'
+import ToggleButtonGroup from '@mui/material/ToggleButtonGroup'
+import Box from '@mui/material/Box'
+import IconButton from '@mui/material/IconButton'
+import PushPinIcon from '@mui/icons-material/PushPin'
+import PushPinOutlinedIcon from '@mui/icons-material/PushPinOutlined'
+import CircleIcon from '@mui/icons-material/Circle'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import ErrorIcon from '@mui/icons-material/Error'
+import Typography from '@mui/material/Typography'
+
+interface AnnotationManagerProps {
+  open: boolean
+  onClose: () => void
+  request: Request | null
+  annotation?: RequestAnnotation
+  onSave: (annotation: RequestAnnotation) => void
+  onDelete: () => void
+}
+
+const colorOptions: { value: RequestColor; color: string; label: string }[] = [
+  { value: 'default', color: '#757575', label: 'Default' },
+  { value: 'red', color: '#f44336', label: 'Red' },
+  { value: 'orange', color: '#ff9800', label: 'Orange' },
+  { value: 'yellow', color: '#ffeb3b', label: 'Yellow' },
+  { value: 'green', color: '#4caf50', label: 'Green' },
+  { value: 'blue', color: '#2196f3', label: 'Blue' },
+  { value: 'purple', color: '#9c27b0', label: 'Purple' },
+]
+
+const statusOptions: { value: RequestStatus; icon: React.ReactNode; label: string }[] = [
+  { value: 'none', icon: <CircleIcon />, label: 'None' },
+  { value: 'resolved', icon: <CheckCircleIcon />, label: 'Resolved' },
+  { value: 'needs-attention', icon: <ErrorIcon />, label: 'Needs Attention' },
+]
+
+export function AnnotationManager({ open, onClose, request, annotation, onSave, onDelete }: AnnotationManagerProps) {
+  const [note, setNote] = useState('')
+  const [color, setColor] = useState<RequestColor>('default')
+  const [status, setStatus] = useState<RequestStatus>('none')
+  const [isPinned, setIsPinned] = useState(false)
+
+  useEffect(() => {
+    if (annotation) {
+      setNote(annotation.note)
+      setColor(annotation.color)
+      setStatus(annotation.status)
+      setIsPinned(annotation.isPinned)
+    } else {
+      setNote('')
+      setColor('default')
+      setStatus('none')
+      setIsPinned(false)
+    }
+  }, [annotation, open])
+
+  const handleSave = () => {
+    const now = Date.now()
+    const newAnnotation: RequestAnnotation = {
+      id: annotation?.id || `${now}`,
+      note,
+      color,
+      status,
+      isPinned,
+      createdAt: annotation?.createdAt || now,
+      updatedAt: now,
+    }
+    onSave(newAnnotation)
+    onClose()
+  }
+
+  const handleColorChange = (_: React.MouseEvent<HTMLElement>, newColor: RequestColor | null) => {
+    if (newColor !== null) {
+      setColor(newColor)
+    }
+  }
+
+  const handleStatusChange = (_: React.MouseEvent<HTMLElement>, newStatus: RequestStatus | null) => {
+    if (newStatus !== null) {
+      setStatus(newStatus)
+    }
+  }
+
+  if (!request) return null
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
+      <DialogTitle>
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Typography variant="h6">Annotate Request</Typography>
+          <IconButton onClick={() => setIsPinned(!isPinned)} color={isPinned ? 'primary' : 'default'}>
+            {isPinned ? <PushPinIcon /> : <PushPinOutlinedIcon />}
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3, pt: 1 }}>
+          <TextField
+            label="Note"
+            multiline
+            rows={4}
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            fullWidth
+            variant="outlined"
+            placeholder="Add a note about this request..."
+          />
+
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Color
+            </Typography>
+            <ToggleButtonGroup
+              value={color}
+              exclusive
+              onChange={handleColorChange}
+              aria-label="request color"
+              sx={{ flexWrap: 'wrap' }}
+            >
+              {colorOptions.map((option) => (
+                <ToggleButton key={option.value} value={option.value} aria-label={option.label}>
+                  <CircleIcon sx={{ color: option.color }} />
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+          </Box>
+
+          <Box>
+            <Typography variant="subtitle2" gutterBottom>
+              Status
+            </Typography>
+            <ToggleButtonGroup
+              value={status}
+              exclusive
+              onChange={handleStatusChange}
+              aria-label="request status"
+              fullWidth
+            >
+              {statusOptions.map((option) => (
+                <ToggleButton key={option.value} value={option.value} aria-label={option.label}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    {option.icon}
+                    <span>{option.label}</span>
+                  </Box>
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+          </Box>
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        {annotation && (
+          <Button onClick={onDelete} color="error" sx={{ mr: 'auto' }}>
+            Delete Annotation
+          </Button>
+        )}
+        <Button onClick={onClose}>Cancel</Button>
+        <Button onClick={handleSave} variant="contained" color="primary">
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import IconButton from '@mui/material/IconButton';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import { useTheme } from './ThemeContext';
+import { AnnotationProvider } from './AnnotationContext';
 
 type SetAction = {
   action: "set",
@@ -71,56 +72,58 @@ function App() {
   })
 
   return (
-    <Box sx={{
-      display: 'flex',
-      height: '100vh',
-      flexDirection: 'column'
-    }}>
+    <AnnotationProvider>
       <Box sx={{
         display: 'flex',
-        justifyContent: 'flex-end',
-        p: 1,
-        borderBottom: 1,
-        borderColor: 'divider'
-      }}>
-        <IconButton onClick={toggleTheme} color="inherit">
-          {isDarkMode ? <Brightness7Icon /> : <Brightness4Icon />}
-        </IconButton>
-      </Box>
-      <Box sx={{
-        display: 'flex',
-        flex: 1,
-        flexDirection: {
-          xs: 'column',
-          md: 'row'
-        }
+        height: '100vh',
+        flexDirection: 'column'
       }}>
         <Box sx={{
-          flex: "1 1 50%",
-          height: {
-            xs: "50%",
-            md: "100%",
-          },
-          width: {
-            xs: "100%",
-            md: "50%",
-          },
+          display: 'flex',
+          justifyContent: 'flex-end',
+          p: 1,
+          borderBottom: 1,
+          borderColor: 'divider'
         }}>
-          <RequestList
-            requests={requests}
-            selectedRequest={selectedRequest}
-            selectRequest={selectRequest}
-          />
+          <IconButton onClick={toggleTheme} color="inherit">
+            {isDarkMode ? <Brightness7Icon /> : <Brightness4Icon />}
+          </IconButton>
         </Box>
-        {selectedRequest ? (
+        <Box sx={{
+          display: 'flex',
+          flex: 1,
+          flexDirection: {
+            xs: 'column',
+            md: 'row'
+          }
+        }}>
           <Box sx={{
             flex: "1 1 50%",
+            height: {
+              xs: "50%",
+              md: "100%",
+            },
+            width: {
+              xs: "100%",
+              md: "50%",
+            },
           }}>
-            <RequestInspector request={selectedRequest} onClose={() => selectRequest(null)}/>
+            <RequestList
+              requests={requests}
+              selectedRequest={selectedRequest}
+              selectRequest={selectRequest}
+            />
           </Box>
-        ) : null}
+          {selectedRequest ? (
+            <Box sx={{
+              flex: "1 1 50%",
+            }}>
+              <RequestInspector request={selectedRequest} onClose={() => selectRequest(null)}/>
+            </Box>
+          ) : null}
+        </Box>
       </Box>
-    </Box>
+    </AnnotationProvider>
   );
 }
 

--- a/src/RequestInspector.tsx
+++ b/src/RequestInspector.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, ReactNode } from "react"
 import { AgentMessage, Invocation, Receipt, Capability, Proof, Delegation as DelegationType} from "@ucanto/interface"
 import { isDelegation} from '@ucanto/core'
-import { Request, isChromeRequest } from './types'
+import { Request, isChromeRequest, RequestAnnotation } from './types'
 import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Box from '@mui/material/Box';
@@ -31,6 +31,13 @@ import DownloadIcon from '@mui/icons-material/Download';
 import { Fragment } from 'react'
 import { Delegation } from "@ucanto/core/delegation";
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+import { useAnnotations, getRequestId } from './AnnotationContext';
+import { AnnotationManager } from './AnnotationManager';
+import EditNoteIcon from '@mui/icons-material/EditNote';
+import PushPinIcon from '@mui/icons-material/PushPin';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+import Chip from '@mui/material/Chip';
  
 function TableDisplay({ size,  index , children} : React.PropsWithChildren<{size? : "small" | "medium", index : Record<string, React.ReactNode> }>) {
   return (
@@ -251,7 +258,6 @@ function MessageDisplay({message, request, type} : { message : AgentMessage, req
   const handleSave = async () => {
     if (isChromeRequest(request)) {
       if (type === 'request') {
-        // For request, we need to get the request body
         const anyReq: any = request as any
         const postData = anyReq?.request?.postData
         if (postData?.text) {
@@ -271,7 +277,6 @@ function MessageDisplay({message, request, type} : { message : AgentMessage, req
           URL.revokeObjectURL(url)
         }
       } else {
-        // For response, get the response body
         request.getContent((content, encoding) => {
           if (content) {
             let decoded = content
@@ -408,11 +413,24 @@ function CustomTabPanel(props: TabPanelProps) {
 
 function RequestInspector({request, onClose} : {request: Request, onClose: () => void}) {
   const [tabIndex, setTabIndex] = useState(0)
+  const [annotationDialogOpen, setAnnotationDialogOpen] = useState(false)
+  const { getAnnotation, setAnnotation, deleteAnnotation } = useAnnotations()
+  const requestId = getRequestId(request)
+  const annotation = getAnnotation(requestId)
   const status = getRequestStatus(request);
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setTabIndex(newValue);
   };
+
+  const handleSaveAnnotation = (newAnnotation: RequestAnnotation) => {
+    setAnnotation(requestId, newAnnotation)
+  }
+
+  const handleDeleteAnnotation = () => {
+    deleteAnnotation(requestId)
+    setAnnotationDialogOpen(false)
+  }
 
   return (
     <Paper sx={{ height: "100%", overflowY: "scroll" }} elevation={3}>
@@ -425,15 +443,44 @@ function RequestInspector({request, onClose} : {request: Request, onClose: () =>
             mr: 1 
           }} 
         />
+        {annotation?.isPinned && (
+          <Tooltip title="Pinned">
+            <PushPinIcon sx={{ fontSize: 16, color: 'primary.main', mr: 1 }} />
+          </Tooltip>
+        )}
+        {annotation?.status === 'resolved' && (
+          <Tooltip title="Resolved">
+            <CheckCircleIcon sx={{ fontSize: 16, color: 'success.main', mr: 1 }} />
+          </Tooltip>
+        )}
+        {annotation?.status === 'needs-attention' && (
+          <Tooltip title="Needs Attention">
+            <ErrorIcon sx={{ fontSize: 16, color: 'error.main', mr: 1 }} />
+          </Tooltip>
+        )}
         <Tooltip title="Close panel">
           <IconButton onClick={onClose}>
             <CloseIcon />
           </IconButton>
         </Tooltip>
-        <Tabs value={tabIndex} onChange={handleChange} aria-label="basic tabs example">
+        <Tooltip title="Edit annotation">
+          <IconButton onClick={() => setAnnotationDialogOpen(true)}>
+            <EditNoteIcon />
+          </IconButton>
+        </Tooltip>
+        <Tabs value={tabIndex} onChange={handleChange} aria-label="basic tabs example" sx={{ ml: 1 }}>
           <Tab label="Request" {...a11yProps(0)} />
           <Tab label="Response" {...a11yProps(1)} />
         </Tabs>
+        {annotation?.note && (
+          <Chip 
+            label="Has note" 
+            size="small" 
+            sx={{ ml: 'auto', mr: 1 }}
+            color="primary"
+            variant="outlined"
+          />
+        )}
       </Box>
       <CustomTabPanel value={tabIndex} index={0}>
         <RequestDisplay request={request}/> 
@@ -442,6 +489,14 @@ function RequestInspector({request, onClose} : {request: Request, onClose: () =>
         <ResponseDisplay request={request} />
       </CustomTabPanel>
     </Box>
+    <AnnotationManager
+      open={annotationDialogOpen}
+      onClose={() => setAnnotationDialogOpen(false)}
+      request={request}
+      annotation={annotation}
+      onSave={handleSaveAnnotation}
+      onDelete={handleDeleteAnnotation}
+    />
     </Paper>
   );
 }

--- a/src/RequestList.tsx
+++ b/src/RequestList.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Request, isChromeRequest } from "./types"
+import React, { useState, useMemo } from 'react'
+import { Request, isChromeRequest, RequestAnnotation } from "./types"
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -11,22 +11,61 @@ import Switch from '@mui/material/Switch';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import { isCarRequest, messageFromRequest, getRequestStatus, getStatusColor, getRequestTiming, formatTiming } from "./util";
 import FiberManualRecordIcon from '@mui/icons-material/FiberManualRecord';
+import { useAnnotations, getRequestId } from './AnnotationContext';
+import { AnnotationManager } from './AnnotationManager';
+import IconButton from '@mui/material/IconButton';
+import EditNoteIcon from '@mui/icons-material/EditNote';
+import PushPinIcon from '@mui/icons-material/PushPin';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import ErrorIcon from '@mui/icons-material/Error';
+import Chip from '@mui/material/Chip';
+import Tooltip from '@mui/material/Tooltip';
+import ClearAllIcon from '@mui/icons-material/ClearAll';
+import Button from '@mui/material/Button';
 
-function RequestEntry({ request, selectedRequest, selectRequest } : {request: Request, selectedRequest: Request | null, selectRequest: (request: Request) => void}) {
+const getAnnotationColor = (color: string): string => {
+  const colorMap: Record<string, string> = {
+    default: '#757575',
+    red: '#f44336',
+    orange: '#ff9800',
+    yellow: '#ffeb3b',
+    green: '#4caf50',
+    blue: '#2196f3',
+    purple: '#9c27b0',
+  }
+  return colorMap[color] || colorMap.default
+}
+
+function RequestEntry({ request, selectedRequest, selectRequest, onEditAnnotation } : {request: Request, selectedRequest: Request | null, selectRequest: (request: Request) => void, onEditAnnotation: (request: Request) => void}) {
+  const { getAnnotation } = useAnnotations()
+  const requestId = getRequestId(request)
+  const annotation = getAnnotation(requestId)
   const message = messageFromRequest(request)
   const status = getRequestStatus(request);
   const timing = getRequestTiming(request)
   const formattedTiming = formatTiming(timing)
   
+  const handleEditClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onEditAnnotation(request)
+  }
+  
   return (
-    <TableRow onClick={() => selectRequest(request)} hover selected={request === selectedRequest}>
+    <TableRow 
+      onClick={() => selectRequest(request)} 
+      hover 
+      selected={request === selectedRequest}
+      sx={{
+        borderLeft: annotation?.color && annotation.color !== 'default' ? `4px solid ${getAnnotationColor(annotation.color)}` : undefined,
+      }}
+    >
       <TableCell sx={{
         maxWidth: '300px',
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',
       }}>
-        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
           <FiberManualRecordIcon 
             sx={{ 
               color: getStatusColor(status), 
@@ -34,7 +73,22 @@ function RequestEntry({ request, selectedRequest, selectRequest } : {request: Re
               mr: 1
             }} 
           />
-          {request.request.url}
+          {annotation?.isPinned && (
+            <Tooltip title="Pinned">
+              <PushPinIcon sx={{ fontSize: 16, color: 'primary.main' }} />
+            </Tooltip>
+          )}
+          {annotation?.status === 'resolved' && (
+            <Tooltip title="Resolved">
+              <CheckCircleIcon sx={{ fontSize: 16, color: 'success.main' }} />
+            </Tooltip>
+          )}
+          {annotation?.status === 'needs-attention' && (
+            <Tooltip title="Needs Attention">
+              <ErrorIcon sx={{ fontSize: 16, color: 'error.main' }} />
+            </Tooltip>
+          )}
+          <span>{request.request.url}</span>
         </Box>
       </TableCell>
       <TableCell sx={{
@@ -46,21 +100,93 @@ function RequestEntry({ request, selectedRequest, selectRequest } : {request: Re
         { typeof message === 'string' ? message : message.invocations.flatMap((invocation) => invocation.capabilities.map((capability => capability.can))).join(", ")}
       </TableCell>
       <TableCell>{formattedTiming}</TableCell>
+      <TableCell sx={{ width: 120 }}>
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+          {annotation?.note && (
+            <Tooltip title={annotation.note}>
+              <Chip 
+                label="Note" 
+                size="small" 
+                variant="outlined"
+                sx={{ height: 20, fontSize: '0.75rem' }}
+              />
+            </Tooltip>
+          )}
+          <IconButton size="small" onClick={handleEditClick}>
+            <EditNoteIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      </TableCell>
     </TableRow>
   )
 }
 
 function RequestList({ requests, selectedRequest, selectRequest } : { requests: Request[], selectedRequest: Request | null, selectRequest: (request: Request) => void }) {
+  const { annotations, getAnnotation, setAnnotation, deleteAnnotation, clearAllAnnotations } = useAnnotations()
+  const [annotationDialogOpen, setAnnotationDialogOpen] = useState(false)
+  const [editingRequest, setEditingRequest] = useState<Request | null>(null)
   const defaultChecked = JSON.parse(localStorage.getItem('persistOnReload') || 'false')
 
   const handlePersistChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     localStorage.setItem('persistOnReload', JSON.stringify(e.target.checked))
   }
 
-  const requestItems = requests.filter(isCarRequest).map((request, idx) => <RequestEntry key={`${request.request.url}-${idx}`} selectedRequest={selectedRequest} selectRequest={selectRequest} request={request} />)
+  const handleEditAnnotation = (request: Request) => {
+    setEditingRequest(request)
+    setAnnotationDialogOpen(true)
+  }
+
+  const handleSaveAnnotation = (annotation: RequestAnnotation) => {
+    if (editingRequest) {
+      const requestId = getRequestId(editingRequest)
+      setAnnotation(requestId, annotation)
+    }
+  }
+
+  const handleDeleteAnnotation = () => {
+    if (editingRequest) {
+      const requestId = getRequestId(editingRequest)
+      deleteAnnotation(requestId)
+      setAnnotationDialogOpen(false)
+    }
+  }
+
+  const sortedRequests = useMemo(() => {
+    const filtered = requests.filter(isCarRequest)
+    return filtered.sort((a, b) => {
+      const aId = getRequestId(a)
+      const bId = getRequestId(b)
+      const aAnnotation = getAnnotation(aId)
+      const bAnnotation = getAnnotation(bId)
+      
+      if (aAnnotation?.isPinned && !bAnnotation?.isPinned) return -1
+      if (!aAnnotation?.isPinned && bAnnotation?.isPinned) return 1
+      
+      return 0
+    })
+  }, [requests, annotations, getAnnotation])
+
+  const requestItems = sortedRequests.map((request, idx) => (
+    <RequestEntry 
+      key={`${request.request.url}-${idx}`} 
+      selectedRequest={selectedRequest} 
+      selectRequest={selectRequest} 
+      request={request}
+      onEditAnnotation={handleEditAnnotation}
+    />
+  ))
   return (
+    <>
     <TableContainer sx={{height: "100%", overflowY: "scroll"}}>
-    <Box sx={{ display: 'flex', justifyContent: 'flex-end', px: 2, py: 1 }}>
+    <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', px: 2, py: 1 }}>
+      <Button
+        startIcon={<ClearAllIcon />}
+        onClick={clearAllAnnotations}
+        size="small"
+        disabled={annotations.size === 0}
+      >
+        Clear All Annotations
+      </Button>
       <FormControlLabel
         control={<Switch defaultChecked={defaultChecked} onChange={handlePersistChange} />}
         label="Persist across reloads"
@@ -82,6 +208,7 @@ function RequestList({ requests, selectedRequest, selectRequest } : { requests: 
           <TableCell>URL</TableCell>
           <TableCell>Capabilities</TableCell>
           <TableCell><abbr title="Round Trip Time">RTT</abbr></TableCell>
+          <TableCell>Actions</TableCell>
         </TableRow>
       </TableHead>
       <TableBody>
@@ -89,6 +216,17 @@ function RequestList({ requests, selectedRequest, selectRequest } : { requests: 
       </TableBody>
     </Table>
     </TableContainer>
+    {editingRequest && (
+      <AnnotationManager
+        open={annotationDialogOpen}
+        onClose={() => setAnnotationDialogOpen(false)}
+        request={editingRequest}
+        annotation={getAnnotation(getRequestId(editingRequest))}
+        onSave={handleSaveAnnotation}
+        onDelete={handleDeleteAnnotation}
+      />
+    )}
+    </>
   )
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,22 @@
 export type Request = chrome.devtools.network.Request | chrome.devtools.network.HAREntry
 
 export const isChromeRequest = (request: Request) : request is chrome.devtools.network.Request => (typeof (request as chrome.devtools.network.Request).getContent === 'function')
+
+export type RequestStatus = 'none' | 'resolved' | 'needs-attention'
+
+export type RequestColor = 'default' | 'red' | 'orange' | 'yellow' | 'green' | 'blue' | 'purple'
+
+export interface RequestAnnotation {
+  id: string
+  note: string
+  color: RequestColor
+  status: RequestStatus
+  isPinned: boolean
+  createdAt: number
+  updatedAt: number
+}
+
+export interface AnnotatedRequest {
+  request: Request
+  annotation?: RequestAnnotation
+}


### PR DESCRIPTION
Add request annotation system with notes, colors, and pinning

- Add ability to annotate requests with custom notes
- Implement color-coding system with 7 color options
- Add pin functionality to keep important requests at top
- Add request status tracking (none/resolved/needs-attention)
- Store annotations in localStorage for persistence
- Add visual indicators for annotations in request list
- Integrate annotation editing in request inspector
- Add "Clear All Annotations" functionality

Closes #56 